### PR TITLE
:bug: Fix link name collision (rename link to linkTool)

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,28 @@ export default {
 }
 ```
 
+## Tools
+### Supported tools
+- header
+- list
+- code
+- inlineCode
+- embed
+- linkTool
+- marker
+- table
+- raw
+- delimiter
+- quote
+- image
+- warning
+- paragraph
+- checklist
+### Usage
+```vue
+<editor header list code ... :config="config"/>
+```
+
 ## Upload Image (>= 1.1.0)
 
 for upload image, You need a backend for processing image. vue-editor-js provide special `config` props for easy.

--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ export default {
 
 ## Tools
 ### Supported tools
+Same as in Supported Plugins, but with different naming
 - header
 - list
 - code

--- a/src/utils.js
+++ b/src/utils.js
@@ -16,7 +16,7 @@ export const PLUGIN_PROPS_TYPE = {
   required: false
 }
 
-export const PLUGIN_PROPS = ['header', 'list', 'code', 'inlineCode', 'embed', 'link', 'marker', 'table', 'raw', 'delimiter', 'quote', 'image', 'warning', 'paragraph', 'checklist']
+export const PLUGIN_PROPS = ['header', 'list', 'code', 'inlineCode', 'embed', 'linkTool', 'marker', 'table', 'raw', 'delimiter', 'quote', 'image', 'warning', 'paragraph', 'checklist']
 
 export const PLUGINS = {
   header: require('@editorjs/header'),
@@ -27,7 +27,7 @@ export const PLUGINS = {
   quote: require('@editorjs/quote'),
   marker: require('@editorjs/marker'),
   code: require('@editorjs/code'),
-  link: require('@editorjs/link'),
+  linkTool: require('@editorjs/link'),
   delimiter: require('@editorjs/delimiter'),
   raw: require('@editorjs/raw'),
   table: require('@editorjs/table'),


### PR DESCRIPTION
Now enabling of the `link` plugin (block-level link embeds) breaks inline links.
The reason is name collision.
This fix renames block-level `link` to `linkTool`, that fixes the issue.
Might be a breaking change for users who use block-level link.

Also:
:memo: Add supported tools and how to use it to README